### PR TITLE
Make \b legal inside Pyret strings.

### DIFF
--- a/mode/pyret.js
+++ b/mode/pyret.js
@@ -146,14 +146,14 @@ CodeMirror.defineMode("pyret", function(config, parserConfig) {
                  "\\\\[01234567]{1,3}" +
                  "|\\\\x[0-9a-fA-F]{1,2}" +
                  "|\\\\u[0-9a-fA-f]{1,4}" +
-                 "|\\\\[\\\\nrt\"\']" +
+                 "|\\\\[\\\\bnrt\"\']" +
                  "|[^\\\\\"\n\r])*\"");
     const squot_str =
       new RegExp("^\'(?:" +
                  "\\\\[01234567]{1,3}" +
                  "|\\\\x[0-9a-fA-F]{1,2}" +
                  "|\\\\u[0-9a-fA-f]{1,4}" +
-                 "|\\\\[\\\\nrt\"\']" +
+                 "|\\\\[\\\\bnrt\"\']" +
                  "|[^\\\\\'\n\r])*\'");
     const unterminated_string = new RegExp("^[\"\'].*");
 


### PR DESCRIPTION
`\b` inside a Pyret string shouldn't throw syntax highlighting.