### PR TITLE
Adding commenting and searching functionality

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <link rel="stylesheet" href="../node_modules/codemirror/lib/codemirror.css"></link>
+  <link rel="stylesheet" href="../node_modules/codemirror/addon/dialog/dialog.css"></link>
+  <link rel="stylesheet" href="../node_modules/codemirror/addon/search/matchesonscrollbar.css"></link>
   <link rel="stylesheet" href="../node_modules/codemirror/addon/fold/foldgutter.css"></link>
   <link rel="stylesheet" href="../css/pyret.css"></link>
 
@@ -9,6 +11,12 @@
   <script src="../node_modules/codemirror/lib/codemirror.js"></script>
   <script src="../node_modules/codemirror/addon/fold/foldcode.js"></script>
   <script src="../node_modules/codemirror/addon/comment/comment.js"></script>
+  <script src="../node_modules/codemirror/addon/dialog/dialog.js"></script>
+  <script src="../node_modules/codemirror/addon/search/searchcursor.js"></script>
+  <script src="../node_modules/codemirror/addon/search/search.js"></script>
+  <script src="../node_modules/codemirror/addon/scroll/annotatescrollbar.js"></script>
+  <script src="../node_modules/codemirror/addon/search/matchesonscrollbar.js"></script>
+  <script src="../node_modules/codemirror/addon/search/jump-to-line.js"></script>
   <script src="../node_modules/codemirror/addon/fold/foldgutter.js"></script>
   <script src="../node_modules/codemirror/addon/selection/mark-selection.js"></script>
   <script src="../node_modules/codemirror/addon/runmode/runmode.js"></script>
@@ -52,6 +60,7 @@ var pyretCM = CodeMirror(document.getElementById("editor"), {
     [`${modifier}-Left`]: "goBackwardToken",
     [`${modifier}-Right`]: "goForwardToken",
     [`${modifier}-/`]: "toggleComment",
+    [`${modifier}-F`]: "findPersistent",
   },
   mode: "pyret",
   lineNumbers: true,

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,6 +8,7 @@
   <script src="utils.js"></script>
   <script src="../node_modules/codemirror/lib/codemirror.js"></script>
   <script src="../node_modules/codemirror/addon/fold/foldcode.js"></script>
+  <script src="../node_modules/codemirror/addon/comment/comment.js"></script>
   <script src="../node_modules/codemirror/addon/fold/foldgutter.js"></script>
   <script src="../node_modules/codemirror/addon/selection/mark-selection.js"></script>
   <script src="../node_modules/codemirror/addon/runmode/runmode.js"></script>
@@ -38,6 +39,9 @@ html, body {
 <pre id="internal"></pre>
 </body>
 <script>
+const mac = CodeMirror.keyMap.default === CodeMirror.keyMap.macDefault;
+const modifier = mac ? "Cmd" : "Ctrl";
+
 var pyretCM = CodeMirror(document.getElementById("editor"), {
   extraKeys: {
     "Tab": "indentAuto",
@@ -45,8 +49,9 @@ var pyretCM = CodeMirror(document.getElementById("editor"), {
     "Alt-Left": "goBackwardSexp",
     "Esc Right": "goForwardSexp",
     "Alt-Right": "goForwardSexp",
-    "Ctrl-Left": "goBackwardToken",
-    "Ctrl-Right": "goForwardToken"
+    [`${modifier}-Left`]: "goBackwardToken",
+    [`${modifier}-Right`]: "goForwardToken",
+    [`${modifier}-/`]: "toggleComment",
   },
   mode: "pyret",
   lineNumbers: true,

--- a/mode/pyret.js
+++ b/mode/pyret.js
@@ -1069,7 +1069,12 @@ CodeMirror.defineMode("pyret", function(config, parserConfig) {
                  types: pyret_delimiter_type},
 
     // FIXME: Should be deleted
-    unprefixedContexts: ["SHARED", "OBJECT"]
+    unprefixedContexts: ["SHARED", "OBJECT"],
+
+    blockCommentStart: "#|",
+    blockCommentEnd: "|#",
+    blockCommentContinue: "",
+    lineComment: "#",
 
   };
   return external;


### PR DESCRIPTION
# Intro
This PR introduces commenting and searching functionality to the Pyret Codemirror mode, and makes minor fixes to the example keybinds. 

# Commenting
Commenting is implemented by specifying `lineComment`, `blockComment*` information into `pyret.js`. Together with importing necessary scripts, enable using [Control or Command]-[/ Slash] (depending on platform) to uncomment blocks of code, or to comment lines/multiple lines. 

# Search
Also added are Codemirror search extension scripts to the `index.html` example. This should also be added to CPO to enable search (and regular expression search) functionality. 

These are only examples of how to add the search functionality, each client that uses the Pyret mode still needs to manually import necessary Codemirror extensions. 

# Testing
Tested functionality using `examples/index.html` and by importing this package into an instance of `code.pyret.org` and observing that added functionality works. 

_Note: This is depended on by brownplt/code.pyret.org#452._